### PR TITLE
Build dependencies during docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,67 +23,13 @@ It contains the URDF model of the robot with accurate visual meshes.
  - /noah/odom
  - /noah/cmd_vel
 
-## Official supported platform:
+## Officially supported platform:
  - Ubuntu version: Focal Fossa 20.04
  - ROS Version: Foxy Fitzroy
  - Gazebo version: 11
 
 _Note: Are you looking for the ROS1 simulation? See [here](https://github.com/Ekumen-OS/Noah-bot-simulation)._
 
-
-## Installation using a Docker container
-
-1. [Install docker](https://docs.docker.com/engine/install/ubuntu/)
-2. Clone this repository.
-3. Build the docker image.
-   ```sh
-   ./Noah-bot-simulation-ros2/docker/build
-   ```
-4. Run the script to run the docker container and mount the project. **IMPORTANT**: If the user does not own an nvidia gpu, delete the "--gpus all \" line from the script.
-   ```sh
-   ./Noah-bot-simulation-ros2/docker/run
-   ```
-5. Download dependencies for the packages
-    ```sh
-    cd /home/colcon_ws
-    sudo apt-get update
-    rosdep install --from-paths src --ignore-src -r -y
-    ```
-6. Build the project and source the workspace
-    ```sh
-    cd /home/colcon_ws
-    colcon build
-    source install/setup.bash
-    source /usr/share/gazebo/setup.bash
-    ```
-7. It is ready to be used!. See [Run Simulation]
-8. If more terminals are needed to be opened, in a new terminal run:
-    ```sh
-    docker exec -it noah_docker_ros2_process bash
-    source /opt/ros/foxy/setup.bash
-    source /home/colcon_ws/install/setup.bash
-    # If running gazebo simulation here:
-    source /usr/share/gazebo/setup.bash
-    ```
-
-## Non-containerized Installation
-
-1. [Install ROS Foxy Fitzroy](https://docs.ros.org/en/foxy/Installation.html)
-2. [Install Gazebo 11](https://classic.gazebosim.org/tutorials?tut=install_ubuntu)
-3. Clone this repository in your `colcon` workspace.
-    ```
-    ├── colcon_ws
-        └── src
-            └── Noah-bot-simulation-ros2
-    ```
-4. `rosdep install --from-paths src --ignore-src -r -y`
-5. Build the project and source the workspace
-    ```sh
-    colcon build
-    source install/setup.bash
-    source /usr/share/gazebo/setup.bash
-    ```
-6. It is ready to be used!. See [Run Simulation](README.md#run-simulation)!
 
 ## Repository organization
 
@@ -106,7 +52,68 @@ Summary of of the packages in the repository.
    - Spawn Noah
    - Run rviz2 (optional)
 
-## Run Simulation!
+
+## Using docker
+
+### Building the code
+
+1. [Install docker](https://docs.docker.com/engine/install/ubuntu/)
+2. If using nvidia, install [nvidia-docker](https://github.com/NVIDIA/nvidia-docker)
+3. Clone this repository.
+4. Build the docker image running:
+   ```sh
+   DOCKER_BUILDKIT=1 docker build -t noahbot:foxy -f docker/Dockerfile .
+   ```
+   After this, the image tagged as `noahbot:foxy` will be ready to run the Noahbot simulation.
+
+### Running the simulation
+
+Run:
+```sh
+./docker/run ros2 launch noah_gazebo noah_gazebo.launch.py
+```
+To start the simulation.
+
+### Quickly test changes without rebuilding the container
+
+If you want to test code changes quickly without rebuilding the container, you can use the `develop` script:
+
+```sh
+$ ./docker/develop
+```
+
+Which will open a shell inside the container, mounting the local copy of the ROS packages.
+You can quickly re-build the code with:
+
+```sh
+$ cd /colcon_ws
+$ colcon build
+```
+
+The `develop` script will also run the containers with host networking, so if you open multiple ones
+you can easily send ROS messages across them.
+
+## Non-containerized Installation
+
+1. [Install ROS Foxy Fitzroy](https://docs.ros.org/en/foxy/Installation.html)
+2. [Install Gazebo 11](https://classic.gazebosim.org/tutorials?tut=install_ubuntu)
+3. Clone this repository in your `colcon` workspace.
+    ```
+    ├── colcon_ws
+        └── src
+            └── Noah-bot-simulation-ros2
+    ```
+4. `rosdep install --from-paths src --ignore-src -r -y`
+5. Build the project and source the workspace
+    ```sh
+    colcon build
+    source install/setup.bash
+    source /usr/share/gazebo/setup.bash
+    ```
+6. It is ready to be used!. See [Run Simulation](README.md#run-simulation)!
+
+
+### Run Simulation!
 
 ```sh
 ros2 launch noah_gazebo noah_gazebo.launch.py

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM osrf/ros:foxy-desktop
+
+ARG COLCON_WS=/colcon_ws
+
+COPY noah_description ${COLCON_WS}/src/noah_description
+COPY noah_gazebo ${COLCON_WS}/src/noah_gazebo
+RUN apt-get update && \
+    apt-get -y dist-upgrade && \
+    . /opt/ros/foxy/setup.sh && \
+    rosdep update && \
+    rosdep install --from-paths ${COLCON_WS}/src --ignore-src -r -y && \
+    colcon build --base-paths ${COLCON_WS}/src/ --build-base ${COLCON_WS}/build --install-base ${COLCON_WS}/install
+
+COPY docker/entrypoint.bash entrypoint.bash
+ENTRYPOINT [ "/entrypoint.bash" ]
+
+CMD ["/bin/bash"]

--- a/docker/build
+++ b/docker/build
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-ABSDIR=$(dirname $(readlink -f $0))
-SCRIPTS_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-
-docker build -t docker_foxy_noahbot ${SCRIPTS_DIR}

--- a/docker/develop
+++ b/docker/develop
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Opens a shell in the Noah simulation container, with the local copy of the
+# code mounted. It uses --net host, to allow for multiple containers to share
+# ROS messages easily.
+
+SCRIPTS_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+REPO_DIR=`readlink -f ${SCRIPTS_DIR}/../`
+DOCKER_MOUNT_ARGS="-v ${REPO_DIR}/:/colcon_ws/src"
+
+xhost +local:root
+
+docker run -it -e DISPLAY -v "/tmp/.X11-unix:/tmp/.X11-unix:rw" \
+	${DOCKER_MOUNT_ARGS} \
+	--net=host \
+	--gpus all \
+    --name noah_docker_ros2_devel \
+    --rm noahbot:foxy /bin/bash

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -1,5 +1,0 @@
-FROM osrf/ros:foxy-desktop
-
-RUN apt-get update
-
-CMD ["/bin/echo", ""]

--- a/docker/entrypoint.bash
+++ b/docker/entrypoint.bash
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+export ROS_DISTRO=foxy
+export COLCON_WS=/colcon_ws
+
+# setup ros2 environment
+source "/opt/ros/${ROS_DISTRO}/setup.bash" --
+# source gazebo
+source /usr/share/gazebo/setup.bash --
+# source the colcon workspace
+source "${COLCON_WS}/install/setup.bash" --
+
+exec "$@"

--- a/docker/run
+++ b/docker/run
@@ -1,16 +1,12 @@
 #!/bin/bash
-
-ABSDIR=$(dirname $(readlink -f $0))
-
-SCRIPTS_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-REPO_DIR=`readlink -f ${SCRIPTS_DIR}/../`
-DOCKER_MOUNT_ARGS="-v ${REPO_DIR}/:/home/colcon_ws/src"
+# Runs the provided command in a docker container with Noah simulation code and dependencies.
 
 xhost +local:root
-docker run -it -e DISPLAY -v "/tmp/.X11-unix:/tmp/.X11-unix:rw" \
-	${DOCKER_MOUNT_ARGS} \
-	-e "TERM=xterm-256color" \
-	--net=host \
+docker run --rm -it \
+	--name noah_docker_ros2_run \
 	--gpus all \
-    --name noah_docker_ros2_process \
-	--privileged --rm docker_foxy_noahbot /bin/bash
+	-e "TERM=xterm-256color" \
+    -e DISPLAY \
+	-v "/tmp/.X11-unix:/tmp/.X11-unix:rw" \
+	noahbot:foxy \
+	$@


### PR DESCRIPTION
Closes #7 

- Updates the Dockerfile to install deps and build code during `docker build`
- Adds a custom entrypoint to source all required files
- Simplifies the documentation
- Changes the run script to not run commands provided by the command line.
- Adds a new `develop` script that will mount the checked out copy and drop to a shell inside the container.