### PR TITLE
Fix odometry publishing

### DIFF
--- a/noah_description/urdf/accurate_base_link.urdf.xacro
+++ b/noah_description/urdf/accurate_base_link.urdf.xacro
@@ -12,6 +12,20 @@
 
 		<!-- BASE************************************************************************** -->
 
+        <link name="base_footprint">			
+            <!--
+            Dummy inertia-less link to prevent the following error:
+            [robot_state_publisher-1] The root link base_generic_link has an inertia specified in the URDF, but KDL does not support a root link with an inertia.
+            As a workaround, you can add an extra dummy link to your URDF.
+            -->
+        </link>
+
+        <joint name="base_frootprint_joint" type="fixed">
+            <parent link="base_footprint" />
+            <child link="base_generic_link" />
+            <origin xyz="0 0 0" rpy="0 0 0" />
+        </joint>
+
 		<xacro:property name="base_generic_depth" value="0.19"/>
 		<xacro:property name="base_generic_width" value="0.135"/>
 		<xacro:property name="base_generic_heigth" value="0.003"/>

--- a/noah_description/urdf/accurate_noah.urdf.xacro
+++ b/noah_description/urdf/accurate_noah.urdf.xacro
@@ -1,96 +1,87 @@
 <?xml version="1.0"?>
 <robot name="accurate_noah"
-	xmlns:xacro="http://www.ros.org/wiki/xacro">
+    xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-	<xacro:include filename="$(find noah_description)/urdf/materials.xacro" />
-	<xacro:include filename="$(find noah_description)/urdf/wheel.urdf.xacro" />
-	<xacro:include filename="$(find noah_description)/urdf/camera_sensor.urdf.xacro" />
-	<xacro:include filename="$(find noah_description)/urdf/accurate_base_link.urdf.xacro" />
-	<xacro:include filename="$(find noah_description)/urdf/caster_link.urdf.xacro" />
-
-
-	<xacro:property name="M_PI" value="3.14159"/>
-
-	<!-- Whole accurate_base_link dimensions -->
-	<xacro:property name="base_width" value="0.16426" />
-	<xacro:property name="base_depth" value="0.19" />
-	<xacro:property name="base_height" value="0.056" />
-
-	<xacro:property name="caster_radius" value="0.022" />
-
-	<xacro:property name="wheel_length" value="0.02" />
-	<xacro:property name="wheel_radius" value="0.05" />
-
-	<xacro:property name="camera_size" value="0.02" />
+    <xacro:include filename="$(find noah_description)/urdf/materials.xacro" />
+    <xacro:include filename="$(find noah_description)/urdf/wheel.urdf.xacro" />
+    <xacro:include filename="$(find noah_description)/urdf/camera_sensor.urdf.xacro" />
+    <xacro:include filename="$(find noah_description)/urdf/accurate_base_link.urdf.xacro" />
+    <xacro:include filename="$(find noah_description)/urdf/caster_link.urdf.xacro" />
 
 
-	<!-- Base Link -->
-	<xacro:accurate_base_link />
+    <xacro:property name="M_PI" value="3.14159" />
 
-	<!-- Caster -->
-	<xacro:caster caster_radius="${caster_radius}" parent_link="caster_holder_link">
-		<origin xyz="0 0 0" rpy="0 0 0" />
-	</xacro:caster>
+    <!-- Whole accurate_base_link dimensions -->
+    <xacro:property name="base_width" value="0.16426" />
+    <xacro:property name="base_depth" value="0.19" />
+    <xacro:property name="base_height" value="0.056" />
+
+    <xacro:property name="caster_radius" value="0.022" />
+
+    <xacro:property name="wheel_length" value="0.02" />
+    <xacro:property name="wheel_radius" value="0.05" />
+
+    <xacro:property name="camera_size" value="0.02" />
 
 
-	<!-- Wheels -->
-	<xacro:noah_wheel wheel_prefix="left" wheel_length="${wheel_length}" wheel_radius="${wheel_radius}" parent_link="left_wheel_adapter_link">
-		<origin xyz="0 ${wheel_length/2} 0" rpy="0 0 0" />
-	</xacro:noah_wheel>
+    <!-- Base Link -->
+    <xacro:accurate_base_link />
 
-	<xacro:noah_wheel wheel_prefix="right" wheel_length="${wheel_length}" wheel_radius="${wheel_radius}" parent_link="right_wheel_adapter_link">
-		<origin xyz="0 -${wheel_length/2} 0" rpy="0 0 0" />
-	</xacro:noah_wheel>
+    <!-- Caster -->
+    <xacro:caster caster_radius="${caster_radius}" parent_link="caster_holder_link">
+        <origin xyz="0 0 0" rpy="0 0 0" />
+    </xacro:caster>
 
-	<!-- Camera -->
-	<xacro:noah_camera camera_size="${camera_size}" parent_link="top_generic_link">
-		<!-- 0.0015 is half the heigth of top generic link -->
-		<origin xyz="${base_depth/3} 0 ${camera_size/2 + 0.0015}" rpy="0 0 0" />
-	</xacro:noah_camera>
 
-	<!-- *******Gazebo specific******* -->
+    <!-- Wheels -->
+    <xacro:noah_wheel wheel_prefix="left" wheel_length="${wheel_length}"
+        wheel_radius="${wheel_radius}" parent_link="left_wheel_adapter_link">
+        <origin xyz="0 ${wheel_length/2} 0" rpy="0 0 0" />
+    </xacro:noah_wheel>
 
-	<gazebo>
-    <!-- For ros2 we use gazebo_ros_joint_state_publisher instead of publishWheelJointState -->
-    <plugin name="joint_states" filename="libgazebo_ros_joint_state_publisher.so">
-      <joint_name>right_wheel_joint</joint_name>
-      <joint_name>left_wheel_joint</joint_name>
-    </plugin>
+    <xacro:noah_wheel wheel_prefix="right" wheel_length="${wheel_length}"
+        wheel_radius="${wheel_radius}" parent_link="right_wheel_adapter_link">
+        <origin xyz="0 -${wheel_length/2} 0" rpy="0 0 0" />
+    </xacro:noah_wheel>
 
-		<plugin name="diff_drive" filename="libgazebo_ros_diff_drive.so">
+    <!-- Camera -->
+    <xacro:noah_camera camera_size="${camera_size}" parent_link="top_generic_link">
+        <!-- 0.0015 is half the heigth of top generic link -->
+        <origin xyz="${base_depth/3} 0 ${camera_size/2 + 0.0015}" rpy="0 0 0" />
+    </xacro:noah_camera>
 
-      <ros>
-        <namespace>/noah</namespace>
-        <!-- For the topics being published we would remap doing: -->
-        <!-- <argument>cmd_vel:=cmd_demo</argument> -->
-        <!-- <argument>odom:=odom_demo</argument> -->
-      </ros>
+    <!-- *******Gazebo specific******* -->
 
-      <!-- wheels -->
-      <left_joint>left_wheel_joint</left_joint>
-      <right_joint>right_wheel_joint</right_joint>
+    <gazebo>
+        <plugin name="diff_drive" filename="libgazebo_ros_diff_drive.so">
 
-      <!-- kinematics -->
-      <wheel_separation>1.25</wheel_separation>
-      <wheel_diameter>0.3</wheel_diameter>
+            <ros>
+                <namespace>/noah</namespace>
+            </ros>
 
-      <!-- limits -->
-      <max_wheel_torque>20</max_wheel_torque>
-      <max_wheel_acceleration>1.0</max_wheel_acceleration>
+            <!-- wheels -->
+            <left_joint>left_wheel_joint</left_joint>
+            <right_joint>right_wheel_joint</right_joint>
 
-      <!-- output -->
-			<update_rate>20</update_rate>
-      <publish_odom>true</publish_odom>
-      <publish_odom_tf>true</publish_odom_tf>
+            <!-- kinematics -->
+            <wheel_separation>1.25</wheel_separation>
+            <wheel_diameter>0.3</wheel_diameter>
 
-      <odometry_frame>odom</odometry_frame>
-      <robot_base_frame>base_generic_link</robot_base_frame>
+            <!-- limits -->
+            <max_wheel_torque>20</max_wheel_torque>
+            <max_wheel_acceleration>1.0</max_wheel_acceleration>
 
-			<command_topic>cmd_vel</command_topic>
-      <publish_wheel_tf>true</publish_wheel_tf>
-			<torque>20</torque>
+            <!-- output -->
+            <update_rate>20</update_rate>
+            <publish_odom>true</publish_odom>
+            <publish_odom_tf>true</publish_odom_tf>
 
-		</plugin>
-	</gazebo>
+            <odometry_frame>odom</odometry_frame>
+            <robot_base_frame>base_footprint</robot_base_frame>
+
+            <publish_wheel_tf>true</publish_wheel_tf>
+
+        </plugin>
+    </gazebo>
 
 </robot>

--- a/noah_gazebo/rviz/noah_gazebo.rviz
+++ b/noah_gazebo/rviz/noah_gazebo.rviz
@@ -62,6 +62,10 @@ Visualization Manager:
         Expand Link Details: false
         Expand Tree: false
         Link Tree Style: Links in Alphabetic Order
+        base_footprint:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
         base_generic_link:
           Alpha: 1
           Show Axes: false
@@ -186,7 +190,7 @@ Visualization Manager:
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
-    Fixed Frame: base_generic_link
+    Fixed Frame: odom
     Frame Rate: 30
   Name: root
   Tools:
@@ -226,7 +230,7 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz_default_plugins/Orbit
-      Distance: 19.701248168945312
+      Distance: 1.0305042266845703
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1


### PR DESCRIPTION
With these changes we can see the robot position history using the odometry visualization in rviz:
![Screenshot from 2022-12-16 17-10-31](https://user-images.githubusercontent.com/764126/208141730-f9064fbb-f99f-420c-b065-0389f2e46c7a.png)

I re-indented one of the xacro files because it was hard to edit if not. I tried to minimize the changes to the other one though.

Closes #10 
