### PR TITLE
Add integration test package and headless mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ you can easily send ROS messages across them.
     source install/setup.bash
     source /usr/share/gazebo/setup.bash
     ```
-6. It is ready to be used!. See [Run Simulation](README.md#run-simulation)!
+6. It is ready to be used! See [Run Simulation](README.md#run-simulation)!
 
 
 ### Run Simulation!
@@ -129,6 +129,11 @@ Use the `rviz` argument and run `rviz2` along the simulation!
 
 ```sh
 ros2 launch noah_gazebo noah_gazebo.launch.py rviz:=true
+```
+
+You can also start the simulation without the Gazebo GUI when you don't have a display (like in CI):
+```sh
+ros2 launch noah_gazebo noah_gazebo.launch.py gazebo_gui:=false
 ```
 
 Try Teleoperating Noah!

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,7 @@ ARG COLCON_WS=/colcon_ws
 
 COPY noah_description ${COLCON_WS}/src/noah_description
 COPY noah_gazebo ${COLCON_WS}/src/noah_gazebo
+COPY noah_integration_tests ${COLCON_WS}/src/noah_integration_tests
 RUN apt-get update && \
     apt-get -y dist-upgrade && \
     . /opt/ros/foxy/setup.sh && \
@@ -13,5 +14,5 @@ RUN apt-get update && \
 
 COPY docker/entrypoint.bash entrypoint.bash
 ENTRYPOINT [ "/entrypoint.bash" ]
-
+WORKDIR ${COLCON_WS}
 CMD ["/bin/bash"]

--- a/noah_gazebo/launch/noah_gazebo.launch.py
+++ b/noah_gazebo/launch/noah_gazebo.launch.py
@@ -8,7 +8,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
-from launch.substitutions import PathJoinSubstitution, TextSubstitution
+from launch.substitutions import PathJoinSubstitution
 from launch_ros.substitutions import FindPackageShare
 from launch_ros.actions import Node
 
@@ -18,7 +18,6 @@ pkg_noah_description = get_package_share_directory('noah_description')
 pkg_noah_gazebo = get_package_share_directory('noah_gazebo')
 
 def generate_launch_description():
-
     # Arguments
     rviz_argument = DeclareLaunchArgument('rviz', default_value='false',
                           description='Open RViz.')
@@ -28,6 +27,7 @@ def generate_launch_description():
           description='SDF world file name')
     verbose_argument = DeclareLaunchArgument('verbose', default_value='false',
                           description='Open Gazebo in verbose mode.')
+    gazebo_gui = DeclareLaunchArgument('gazebo_gui', default_value='true', description='Open Gazebo GUI.')
 
     # Includes gazebo_ros launch for gazebo
     include_gazebo = IncludeLaunchDescription(
@@ -37,6 +37,7 @@ def generate_launch_description():
           launch_arguments = {
               'world': LaunchConfiguration('world'), # It is looking relative at GAZEBO_RESOURCE_PATH.
               'verbose': LaunchConfiguration('verbose'),
+              'gui': LaunchConfiguration('gazebo_gui'),
           }.items()
     )
 
@@ -76,6 +77,7 @@ def generate_launch_description():
         rviz_argument,
         world_argument,
         verbose_argument,
+        gazebo_gui,
         rviz,
         include_noah_description,
         include_gazebo,

--- a/noah_integration_tests/CMakeLists.txt
+++ b/noah_integration_tests/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(noah_integration_tests)
+
+find_package(ament_cmake REQUIRED)
+
+if(BUILD_TESTING)
+  find_package(rclcpp REQUIRED)
+  find_package(nav_msgs REQUIRED)
+  find_package(ament_cmake_gtest REQUIRED)
+  find_package(ros_testing REQUIRED)
+
+  ament_add_gtest(
+    ${PROJECT_NAME}_odometry_drift_test
+    test/odometry_drift_test.cpp
+    )
+  ament_target_dependencies(${PROJECT_NAME}_odometry_drift_test rclcpp nav_msgs)
+
+  install(TARGETS
+    ${PROJECT_NAME}_odometry_drift_test
+    DESTINATION lib/${PROJECT_NAME})
+
+endif()
+
+ament_package()

--- a/noah_integration_tests/package.xml
+++ b/noah_integration_tests/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+    <name>noah_integration_tests</name>
+    <version>0.1.0</version>
+    <description> Collections of simulation based integration tests for
+        noah. </description>
+    <author email="lucas@gethen.io">Lucas Chiesa</author>
+    <maintainer email="lucas@gethen.io">Lucas Chiesa</maintainer>
+    <license file="../LICENSE">
+        BSD Clause 3</license>
+
+    <buildtool_depend>ament_cmake</buildtool_depend>
+
+    <exec_depend>noah_gazebo</exec_depend>
+    <exec_depend>noah_description</exec_depend>
+    <exec_depend>ros2launch</exec_depend>
+
+    <test_depend>ament_cmake_gtest</test_depend>
+    <test_depend>nav_msgs</test_depend>
+    <test_depend>rclcpp</test_depend>
+    <test_depend>ros_testing</test_depend>
+
+    <export>
+        <build_type>ament_cmake</build_type>
+    </export>
+</package>

--- a/noah_integration_tests/test/odometry_drift_test.cpp
+++ b/noah_integration_tests/test/odometry_drift_test.cpp
@@ -1,0 +1,96 @@
+#include <chrono>
+#include <memory>
+#include <mutex>
+
+#include "geometry_msgs/msg/point.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "gtest/gtest.h"
+
+class OdometryDriftCalculator : public rclcpp::Node {
+public:
+  OdometryDriftCalculator(int capture_miliseconds)
+      : Node("odometry_drift_test") {
+    odom_subscription_ = create_subscription<nav_msgs::msg::Odometry>(
+        "/noah/odom", 10,
+        std::bind(&OdometryDriftCalculator::odometry_callback, this,
+                  std::placeholders::_1));
+    timer_ = create_wall_timer(
+        std::chrono::milliseconds(capture_miliseconds),
+        std::bind(&OdometryDriftCalculator::timer_callback, this));
+  }
+
+  double get_accumulated_drift() const {
+    std::lock_guard<std::mutex> accum_lock(accumulated_odometry_drift_mutex_);
+    return accumulated_odometry_drift_;
+  }
+
+private:
+  void odometry_callback(
+      const nav_msgs::msg::Odometry::SharedPtr current_odometry_msg) {
+    if (!previous_odometry_msg_) {
+      // On reception of the first odom message, reset drift to 0.
+      // This is to fail the test if odometry is never published.
+      RCLCPP_INFO(get_logger(), "First odom message received!.");
+      accumulated_odometry_drift_ = 0.0;
+    } else {
+      update_odometry_drift(current_odometry_msg);
+    }
+
+    previous_odometry_msg_ =
+        std::make_shared<nav_msgs::msg::Odometry>(*current_odometry_msg);
+  }
+
+  void timer_callback() {
+    timer_->cancel();
+    rclcpp::shutdown(nullptr, "Stopping the testing node.");
+  }
+
+  void update_odometry_drift(
+      const nav_msgs::msg::Odometry::SharedPtr current_odometry_msg) {
+    std::lock_guard<std::mutex> accum_lock(accumulated_odometry_drift_mutex_);
+    const geometry_msgs::msg::Point current{
+        current_odometry_msg->pose.pose.position};
+    const geometry_msgs::msg::Point previous{
+        previous_odometry_msg_->pose.pose.position};
+
+    const double current_drift = accumulated_odometry_drift_;
+    const double new_drift = std::abs(current.x - previous.x) +
+                             std::abs(current.y - previous.y) +
+                             std::abs(current.z - previous.z);
+    accumulated_odometry_drift_ = current_drift + new_drift;
+    RCLCPP_INFO(get_logger(), "Currently accumulated drift: " +
+                                  std::to_string(accumulated_odometry_drift_));
+  }
+
+  mutable std::mutex accumulated_odometry_drift_mutex_{};
+  double accumulated_odometry_drift_{std::numeric_limits<double>::infinity()};
+  nav_msgs::msg::Odometry::SharedPtr previous_odometry_msg_{nullptr};
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_subscription_{};
+  rclcpp::TimerBase::SharedPtr timer_{};
+};
+
+#define CAPTURE_MILLISECONDS 1000
+#define MAX_ACCEPTED_DRIFT 1e-3
+
+class OdometryDriftTest : public ::testing::Test {
+public:
+  OdometryDriftTest() {
+    auto node = std::make_shared<OdometryDriftCalculator>(CAPTURE_MILLISECONDS);
+    rclcpp::spin(node);
+    accumulated_drift_ = node->get_accumulated_drift();
+  }
+
+  double accumulated_drift_{0.0};
+};
+
+TEST_F(OdometryDriftTest, IsDriftAccetable) {
+  EXPECT_LE(accumulated_drift_, MAX_ACCEPTED_DRIFT)
+      << "Accumulated drift too high.";
+}
+
+int main(int argc, char *argv[]) {
+  rclcpp::init(argc, argv);
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Including a simple robot does not drift test

To run the test start the simulation, and then run:
```
$ ros2 run noah_integration_tests noah_integration_tests_odometry_drift_test
```
You should see an output like this:
```
root@4baecc5911cd:/colcon_ws# ros2 run noah_integration_tests noah_integration_tests_odometry_drift_test
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from OdometryDriftTest
[ RUN      ] OdometryDriftTest.IsDriftAccetable
[INFO] [1673268422.869056054] [odometry_drift_test]: First odom message received!.
[INFO] [1673268422.918131082] [odometry_drift_test]: Currently accumulated drift: 0.000001
[INFO] [1673268422.965896321] [odometry_drift_test]: Currently accumulated drift: 0.000002
[INFO] [1673268423.016283535] [odometry_drift_test]: Currently accumulated drift: 0.000002
[INFO] [1673268423.353383486] [odometry_drift_test]: Currently accumulated drift: 0.000003
[INFO] [1673268423.353466533] [odometry_drift_test]: Currently accumulated drift: 0.000004
[INFO] [1673268423.353511458] [odometry_drift_test]: Currently accumulated drift: 0.000005
[INFO] [1673268423.353546554] [odometry_drift_test]: Currently accumulated drift: 0.000006
[INFO] [1673268423.353698260] [odometry_drift_test]: Currently accumulated drift: 0.000006
[INFO] [1673268423.353740149] [odometry_drift_test]: Currently accumulated drift: 0.000007
[INFO] [1673268423.366899479] [odometry_drift_test]: Currently accumulated drift: 0.000008
[INFO] [1673268423.420928907] [odometry_drift_test]: Currently accumulated drift: 0.000009
[INFO] [1673268423.471269894] [odometry_drift_test]: Currently accumulated drift: 0.000010
[INFO] [1673268423.522373472] [odometry_drift_test]: Currently accumulated drift: 0.000010
[INFO] [1673268423.569856206] [odometry_drift_test]: Currently accumulated drift: 0.000011
[INFO] [1673268423.619760290] [odometry_drift_test]: Currently accumulated drift: 0.000012
[INFO] [1673268423.671839748] [odometry_drift_test]: Currently accumulated drift: 0.000013
[INFO] [1673268423.718960189] [odometry_drift_test]: Currently accumulated drift: 0.000013
[INFO] [1673268423.770886849] [odometry_drift_test]: Currently accumulated drift: 0.000014
[       OK ] OdometryDriftTest.IsDriftAccetable (1012 ms)
[----------] 1 test from OdometryDriftTest (1012 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (1024 ms total)
[  PASSED  ] 1 test.
```

If the simulation is not running, the test will fail as there are no odometry messages, and the drift is infinity:
```
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from OdometryDriftTest
[ RUN      ] OdometryDriftTest.IsDriftAccetable
/colcon_ws/src/noah_integration_tests/test/odometry_drift_test.cpp:87: Failure
Expected: (accumulated_drift_) <= (1e-3), actual: inf vs 0.001
Accumulated drift too high.
[  FAILED  ] OdometryDriftTest.IsDriftAccetable (1015 ms)
[----------] 1 test from OdometryDriftTest (1015 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (1015 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] OdometryDriftTest.IsDriftAccetable

 1 FAILED TEST
```

You can also run the test using `colcon test`:
```
root@Eskarina:/colcon_ws# colcon test --event-handlers console_direct+
Starting >>> noah_description
Finished <<< noah_description [0.04s]
Starting >>> noah_gazebo
Finished <<< noah_gazebo [0.06s]          
Starting >>> noah_integration_tests
UpdateCTestConfiguration  from :/colcon_ws/build/noah_integration_tests/CTestConfiguration.ini
Parse Config file:/colcon_ws/build/noah_integration_tests/CTestConfiguration.ini
   Site: buildkitsandbox
   Build name: (empty)
 Add coverage exclude regular expressions.
SetCTestConfiguration:CMakeCommand:/usr/bin/cmake
Create new tag: 20230110-0946 - Experimental
UpdateCTestConfiguration  from :/colcon_ws/build/noah_integration_tests/CTestConfiguration.ini
Parse Config file:/colcon_ws/build/noah_integration_tests/CTestConfiguration.ini
Test project /colcon_ws/build/noah_integration_tests
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 1
    Start 1: noah_integration_tests_odometry_drift_test

1: Test command: /usr/bin/python3 "-u" "/opt/ros/foxy/share/ament_cmake_test/cmake/run_test.py" "/colcon_ws/build/noah_integration_tests/test_results/noah_integration_tests/noah_integration_tests_odometry_drift_test.gtest.xml" "--package-name" "noah_integration_tests" "--output-file" "/colcon_ws/build/noah_integration_tests/ament_cmake_gtest/noah_integration_tests_odometry_drift_test.txt" "--command" "/colcon_ws/build/noah_integration_tests/noah_integration_tests_odometry_drift_test" "--gtest_output=xml:/colcon_ws/build/noah_integration_tests/test_results/noah_integration_tests/noah_integration_tests_odometry_drift_test.gtest.xml"
1: Test timeout computed to be: 60
1: -- run_test.py: invoking following command in '/colcon_ws/build/noah_integration_tests':
1:  - /colcon_ws/build/noah_integration_tests/noah_integration_tests_odometry_drift_test --gtest_output=xml:/colcon_ws/build/noah_integration_tests/test_results/noah_integration_tests/noah_integration_tests_odometry_drift_test.gtest.xml
1: [==========] Running 1 test from 1 test case.
1: [----------] Global test environment set-up.
1: [----------] 1 test from OdometryDriftTest
1: [ RUN      ] OdometryDriftTest.IsDriftAccetable
1: [INFO] [1673343960.820459652] [odometry_drift_test]: First odom message received!.
1: [INFO] [1673343960.879023392] [odometry_drift_test]: Currently accumulated drift: 0.000001
1: [INFO] [1673343960.927109838] [odometry_drift_test]: Currently accumulated drift: 0.000002
1: [INFO] [1673343960.979029327] [odometry_drift_test]: Currently accumulated drift: 0.000002
1: [INFO] [1673343961.024011861] [odometry_drift_test]: Currently accumulated drift: 0.000003
1: [INFO] [1673343961.073021826] [odometry_drift_test]: Currently accumulated drift: 0.000004
1: [INFO] [1673343961.124044380] [odometry_drift_test]: Currently accumulated drift: 0.000005
1: [INFO] [1673343961.177766612] [odometry_drift_test]: Currently accumulated drift: 0.000005
1: [INFO] [1673343961.228301524] [odometry_drift_test]: Currently accumulated drift: 0.000006
1: [INFO] [1673343961.276068266] [odometry_drift_test]: Currently accumulated drift: 0.000007
1: [INFO] [1673343961.323874034] [odometry_drift_test]: Currently accumulated drift: 0.000008
1: [INFO] [1673343961.374286623] [odometry_drift_test]: Currently accumulated drift: 0.000009
1: [INFO] [1673343961.422902574] [odometry_drift_test]: Currently accumulated drift: 0.000009
1: [INFO] [1673343961.476271266] [odometry_drift_test]: Currently accumulated drift: 0.000010
1: [INFO] [1673343961.526372386] [odometry_drift_test]: Currently accumulated drift: 0.000011
1: [INFO] [1673343961.588337566] [odometry_drift_test]: Currently accumulated drift: 0.000012
1: [INFO] [1673343961.633424678] [odometry_drift_test]: Currently accumulated drift: 0.000012
1: [INFO] [1673343961.677475621] [odometry_drift_test]: Currently accumulated drift: 0.000013
1: [INFO] [1673343961.723505207] [odometry_drift_test]: Currently accumulated drift: 0.000014
1: [INFO] [1673343961.773711326] [odometry_drift_test]: Currently accumulated drift: 0.000015
1: [       OK ] OdometryDriftTest.IsDriftAccetable (1024 ms)
1: [----------] 1 test from OdometryDriftTest (1024 ms total)
1: 
1: [----------] Global test environment tear-down
1: [==========] 1 test from 1 test case ran. (1024 ms total)
1: [  PASSED  ] 1 test.
1: -- run_test.py: return code 0
1: -- run_test.py: inject classname prefix into gtest result file '/colcon_ws/build/noah_integration_tests/test_results/noah_integration_tests/noah_integration_tests_odometry_drift_test.gtest.xml'
1: -- run_test.py: verify result file '/colcon_ws/build/noah_integration_tests/test_results/noah_integration_tests/noah_integration_tests_odometry_drift_test.gtest.xml'
1/1 Test #1: noah_integration_tests_odometry_drift_test ...   Passed    1.16 sec

100% tests passed, 0 tests failed out of 1

Label Time Summary:
gtest    =   1.16 sec*proc (1 test)

Total Test time (real) =   1.16 sec
Finished <<< noah_integration_tests [1.22s]

Summary: 3 packages finished [1.57s]
```
(but you also need to run the simulation first)


This PR also adds the option to start the simulation in headless mode:

```sh
./docker/run ros2 launch noah_gazebo noah_gazebo.launch.py gazebo_gui:=false
```

Closes #9, #14