### PR TITLE
Fix dri gl issues

### DIFF
--- a/docker/develop
+++ b/docker/develop
@@ -10,6 +10,7 @@ DOCKER_MOUNT_ARGS="-v ${REPO_DIR}/:/colcon_ws/src"
 xhost +local:root
 
 docker run -it -e DISPLAY -v "/tmp/.X11-unix:/tmp/.X11-unix:rw" \
+	-v /dev/dri:/dev/dri \
 	${DOCKER_MOUNT_ARGS} \
 	--net=host \
 	--gpus all \

--- a/docker/run
+++ b/docker/run
@@ -7,6 +7,7 @@ docker run --rm -it \
 	--gpus all \
 	-e "TERM=xterm-256color" \
 	-e DISPLAY \
+	-v /dev/dri:/dev/dri \
 	-v "/tmp/.X11-unix:/tmp/.X11-unix:rw" \
 	noahbot:humble \
 	$@


### PR DESCRIPTION
Related to #20 

Adds /dev/dri volume to docker container, allowing for RVIz and Gazebo to properly render