### PR TITLE
Launch empty simulation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,38 +8,18 @@ COPY noah_integration_tests ${COLCON_WS}/src/noah_integration_tests
 COPY noah_webots ${COLCON_WS}/src/noah_webots
 
 # Install Webots
-
-# Dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libxtst6 \
-    python3-pip \
-    python3-tk \
+RUN apt-get update && apt-get install -y \
     software-properties-common \
-    xcb \
-    wget && \
-    rm -rf /var/lib/apt/lists/*
+    wget
 
-# Add key and repository
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ffmpeg \
-    libssh-dev \
-    libzip-dev \
-    libxerces-c-dev \
-    libfox-1.6-dev \
-    libgdal-dev \
-    libproj-dev \
-    libgl2ps-dev
-
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -f install --assume-yes --no-install-recommends xserver-xorg-core
-
-RUN wget https://github.com/cyberbotics/webots/releases/download/R2023a/webots_2023a_amd64.deb
-RUN apt-get install ./webots_2023a_amd64.deb
 RUN wget -qO- https://cyberbotics.com/Cyberbotics.asc | sudo apt-key add -
+
+
 RUN apt-add-repository 'deb https://cyberbotics.com/debian/ binary-amd64/'
 
-
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y --no-install-recommends \
+    apt-get install -y \
+    webots \
     ros-humble-webots-ros2
 
 RUN apt-get update && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,43 @@ ARG COLCON_WS=/colcon_ws
 COPY noah_description ${COLCON_WS}/src/noah_description
 COPY noah_gazebo ${COLCON_WS}/src/noah_gazebo
 COPY noah_integration_tests ${COLCON_WS}/src/noah_integration_tests
+COPY noah_webots ${COLCON_WS}/src/noah_webots
+
+# Install Webots
+
+# Dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libxtst6 \
+    python3-pip \
+    python3-tk \
+    software-properties-common \
+    xcb \
+    wget && \
+    rm -rf /var/lib/apt/lists/*
+
+# Add key and repository
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    libssh-dev \
+    libzip-dev \
+    libxerces-c-dev \
+    libfox-1.6-dev \
+    libgdal-dev \
+    libproj-dev \
+    libgl2ps-dev
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -f install --assume-yes --no-install-recommends xserver-xorg-core
+
+RUN wget https://github.com/cyberbotics/webots/releases/download/R2023a/webots_2023a_amd64.deb
+RUN apt-get install ./webots_2023a_amd64.deb
+RUN wget -qO- https://cyberbotics.com/Cyberbotics.asc | sudo apt-key add -
+RUN apt-add-repository 'deb https://cyberbotics.com/debian/ binary-amd64/'
+
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-recommends \
+    ros-humble-webots-ros2
+
 RUN apt-get update && \
     apt-get -y dist-upgrade && \
     . /opt/ros/humble/setup.sh && \

--- a/noah_webots/CMakeLists.txt
+++ b/noah_webots/CMakeLists.txt
@@ -3,5 +3,12 @@ project(noah_webots)
 
 find_package(ament_cmake REQUIRED)
 
+install(
+  DIRECTORY
+    launch
+    worlds
+  DESTINATION
+    share/${PROJECT_NAME}/
+)
 
 ament_package()

--- a/noah_webots/LICENSE
+++ b/noah_webots/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2023, Ekumen Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/noah_webots/README.md
+++ b/noah_webots/README.md
@@ -1,0 +1,11 @@
+## Noah Webots package
+
+This package should contain all the necessary resources to launch a Webots simulation with the capacity to import and spawn a Noah robot from the `noah_description` package.
+
+### Running the simulation
+
+Once the package has been built with `colcon build` and the setup file sourced, the simulation can be launched by running:
+
+`ros2 launch noah_webots noah_webots.launch.py`
+
+This should start Webots and load the world `myWorld` stored in `/worlds`, along with a Supervisor Node provided by `webots_ros2` called `Ros2Supervisor`. This is a special Supervisor node that interacts with the simulation, allowing different features such as publishing the `/clock` topic, or spawning a robot from a URDF file. This node will be useful when importing an URDF robot in a running simulation. 

--- a/noah_webots/README.md
+++ b/noah_webots/README.md
@@ -1,6 +1,6 @@
 ## Noah Webots package
 
-This package should contain all the necessary resources to launch a Webots simulation with the capacity to import and spawn a Noah robot from the `noah_description` package.
+This package contains all the necessary resources to launch a Webots simulation with the capacity to import and spawn a Noah robot from the `noah_description` package.
 
 ### Running the simulation
 
@@ -8,4 +8,4 @@ Once the package has been built with `colcon build` and the setup file sourced, 
 
 `ros2 launch noah_webots noah_webots.launch.py`
 
-This should start Webots and load the world `myWorld` stored in `/worlds`, along with a Supervisor Node provided by `webots_ros2` called `Ros2Supervisor`. This is a special Supervisor node that interacts with the simulation, allowing different features such as publishing the `/clock` topic, or spawning a robot from a URDF file. This node will be useful when importing an URDF robot in a running simulation. 
+This starts Webots and loads the world `myWorld` stored in `/worlds`, along with a Supervisor Node provided by `webots_ros2` called `Ros2Supervisor`. This is a special Supervisor node that interacts with the simulation, allowing different features such as publishing the `/clock` topic, or spawning a robot from a URDF file. This node will be useful when importing an URDF robot in a running simulation. 

--- a/noah_webots/launch/noah_webots.launch.py
+++ b/noah_webots/launch/noah_webots.launch.py
@@ -1,8 +1,39 @@
+# BSD 3-Clause License
+
+# Copyright (c) 2023, Ekumen Inc.
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import launch
 import os
 import pathlib
-import launch
-from launch_ros.actions import Node
+
 from ament_index_python.packages import get_package_share_directory
+from launch_ros.actions import Node
 from webots_ros2_driver.webots_launcher import WebotsLauncher
 
 # Obtain package

--- a/noah_webots/launch/noah_webots.launch.py
+++ b/noah_webots/launch/noah_webots.launch.py
@@ -15,7 +15,7 @@ def generate_launch_description():
     # - `world` (str):              Path to the world to launch.
     # - `gui` (bool):               Whether to display GUI or not.
     # - `mode` (str):               Can be `pause`, `realtime`, or `fast`.
-    # - `ros2_supervisor` (bool):   Spawn the `Ros2Supervisor` custom node that communicates with a Supervisor robot in the simulation. The Ros2Supervisor node is a special node interacting with the simulation. For example, it publishes the /clock topic of the simulation or permits to spawn robot from URDF files.
+    # - `ros2_supervisor` (bool):   Spawn the `Ros2Supervisor` custom node that communicates with a Supervisor robot in the simulation.
     webots = WebotsLauncher(
         world=os.path.join(package_dir, 'worlds', 'myWorld.wbt'),
         ros2_supervisor=True

--- a/noah_webots/launch/noah_webots.launch.py
+++ b/noah_webots/launch/noah_webots.launch.py
@@ -1,0 +1,37 @@
+import os
+import pathlib
+import launch
+from launch_ros.actions import Node
+from ament_index_python.packages import get_package_share_directory
+from webots_ros2_driver.webots_launcher import WebotsLauncher
+
+# Obtain package
+package_dir = get_package_share_directory('noah_webots')
+
+def generate_launch_description():
+
+    # The WebotsLauncher is used to start a Webots instance.
+    # Arguments:
+    # - `world` (str):              Path to the world to launch.
+    # - `gui` (bool):               Whether to display GUI or not.
+    # - `mode` (str):               Can be `pause`, `realtime`, or `fast`.
+    # - `ros2_supervisor` (bool):   Spawn the `Ros2Supervisor` custom node that communicates with a Supervisor robot in the simulation. The Ros2Supervisor node is a special node interacting with the simulation. For example, it publishes the /clock topic of the simulation or permits to spawn robot from URDF files.
+    webots = WebotsLauncher(
+        world=os.path.join(package_dir, 'worlds', 'myWorld.wbt'),
+        ros2_supervisor=True
+    )
+
+    # Standard ROS 2 launch description
+    return launch.LaunchDescription([
+        # Start the Webots node
+        webots,
+        # Starts the Ros2Supervisor node created with the WebotsLauncher
+        webots._supervisor,
+        # This action will kill all nodes once the Webots simulation has exited
+        launch.actions.RegisterEventHandler(
+            event_handler=launch.event_handlers.OnProcessExit(
+                target_action=webots,
+                on_exit=[launch.actions.EmitEvent(event=launch.events.Shutdown())],
+            )
+        )
+    ])

--- a/noah_webots/package.xml
+++ b/noah_webots/package.xml
@@ -5,7 +5,7 @@
   <version>0.1.0</version>
   <description>Noah simulation in webots_ros2</description>
   <maintainer email="ignacio.davila@ekumenlabs.com">root</maintainer>
-  <license file="../LICENSE"> BSD Clause 3</license>
+  <license file="LICENSE"> BSD Clause 3</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/noah_webots/worlds/myWorld.wbt
+++ b/noah_webots/worlds/myWorld.wbt
@@ -1,0 +1,23 @@
+#VRML_SIM R2023a utf8
+
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023a/projects/objects/backgrounds/protos/TexturedBackground.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023a/projects/objects/floors/protos/RectangleArena.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2023a/projects/objects/backgrounds/protos/TexturedBackgroundLight.proto"
+
+WorldInfo {
+}
+Viewpoint {
+  orientation -0.19228324040611222 0.427838506449861 0.8831655381963666 0.9414602621376631
+  position -6.176311253057089 -5.016661976319434 2.7687437623483975
+}
+TexturedBackground {
+  skyColor [
+    0 0 0
+    0 0 0
+  ]
+}
+TexturedBackgroundLight {
+}
+RectangleArena {
+  floorSize 10 10
+}


### PR DESCRIPTION
- Added a world and launch files to be able to launch a webots simulation using ROS 2 commands.
- The launchfile contains the basic commands to launch webots and the ROS2Supervisor node, used to expand Webots features with ROS 2.
- A README is added to the package to keep track of the added features and changes.